### PR TITLE
Set default environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# For Sinatra configuration, defaults to production. 
+# For local development, set this value to development
+APP_ENV=production
+
+# Twilio API credentials
+# Found at https://www.twilio.com/user/account/settings
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your-token
+TWILIO_APP_SID=app-id

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Webhooks Example (Sinatra)
 
 This tiny repo shows you how to use Twilio webhooks with Sinatra.
+
+## Configure Development vs Production Settings
+
+By default, this application will run in production mode - stack traces will not be visible in the web browser. If you would like to run this application in development locally, change the `APP_ENV` variable in your `.env` file.
+
+`APP_ENV=development`
+
+For more about development vs production, visit [Sinatra's configuration page](http://sinatrarb.com/configuration.html).

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,14 @@
+require 'dotenv'
 require 'sinatra'
 require 'twilio-ruby'
+
+# Load environment configuration
+Dotenv.load
+
+# Set the environment after dotenv loads
+# Default to production
+environment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, environment
 
 before do
   validate_twilio_request()

--- a/client.rb
+++ b/client.rb
@@ -1,5 +1,14 @@
+require 'dotenv'
 require 'sinatra'
 require 'twilio-ruby'
+
+# Load environment configuration
+Dotenv.load
+
+# Set the environment after dotenv loads
+# Default to production
+environment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, environment
 
 # Twilio Client URL
 post '/client/?' do


### PR DESCRIPTION
Set default environment to production.

Changes in the PR:

- Set `APP_ENV` to `production`
- Update README.
